### PR TITLE
src/debug: fix build warning

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -103,7 +103,15 @@ static void debug_mutex_unlock(void)
 #endif
 }
 
-static char* get_filename(const char* path);
+static char* get_filename(const char* path)
+{
+#if __linux__
+    char* ptr = strrchr(path, '/');
+#else
+    char* ptr = strrchr(path, '\\');
+#endif
+    return ptr + 1;
+}
 
 void memory_pool_debug_init(void)
 {
@@ -422,14 +430,4 @@ void memory_pool_debug_trace(void)
             }
         }
     }
-}
-
-static char* get_filename(const char* path)
-{
-#if __linux__
-    char* ptr = strrchr(path, '/');
-#else
-    char* ptr = strrchr(path, '\');
-#endif
-    return ptr + 1;
 }


### PR DESCRIPTION
src/debug: fix build warning

```
[ 75%] Building C object CMakeFiles/mem_pool.dir/src/malloc.c.o /home/runner/work/cMemoryPool/cMemoryPool/src/debug.c: In function ‘get_filename’: /home/runner/work/cMemoryPool/cMemoryPool/src/debug.c:432:31: warning: missing terminating ' character
  432 |     char* ptr = strrchr(path, '\');
      |                               ^
[100%] Linking C executable mem_pool
[100%] Built target mem_pool
```

Signed-off-by: Junbo Zheng <3273070@qq.com>