### PR TITLE
CMakeLists.txt: correct CMAKE_EXPORT_COMPILE_COMMANDS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(mem_pool LANGUAGES C)
 
 include_directories(${PROJECT_SOURCE_DIR}/src)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 set(SRC
     main.c
     src/malloc.c
@@ -20,8 +22,6 @@ add_executable(mem_pool ${SRC})
 if(MEMORY_POOL_DEBUG)
   target_compile_definitions(mem_pool PUBLIC -DCONFIG_MEMORY_POOL_DEBUG=1)
 endif()
-
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_compile_options(-Wall -Wextra -Werror -Wno-format -g)
 


### PR DESCRIPTION
Move `CMAKE_EXPORT_COMPILE_COMMANDS` configuration before the source, so make sure the `CMAKE_EXPORT_COMPILE_COMMANDS` configuration is executed correctly, otherwise, it will not take effect.

Also can type `cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1`, it looks better. Fix #15 