### PR TITLE
fix build warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,16 +2,18 @@ cmake_minimum_required(VERSION 3.10)
 
 project(mem_pool LANGUAGES C)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+option(MEMORY_POOL_DEBUG "memory pool debug"  OFF)
+
 include_directories(${PROJECT_SOURCE_DIR}/src)
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+add_compile_options(-Wall -Wextra -Werror -Wno-format -g)
 
 set(SRC
     main.c
     src/malloc.c
 )
-
-option(MEMORY_POOL_DEBUG "memory pool debug"  OFF)
 
 if(MEMORY_POOL_DEBUG)
   set(SRC ${SRC} src/debug.c)
@@ -22,7 +24,5 @@ add_executable(mem_pool ${SRC})
 if(MEMORY_POOL_DEBUG)
   target_compile_definitions(mem_pool PUBLIC -DCONFIG_MEMORY_POOL_DEBUG=1)
 endif()
-
-add_compile_options(-Wall -Wextra -Werror -Wno-format -g)
 
 target_include_directories(mem_pool PRIVATE "${CMAKE_SOURCE_DIR}/src/")

--- a/src/malloc.c
+++ b/src/malloc.c
@@ -78,23 +78,12 @@ static struct  {
 
     mem_perused,
 
-    mem1pool,
-    mem2pool,
-    mem3pool,
-    mem4pool,
-    mem5pool,
+    {mem1pool,  mem2pool,  mem3pool,  mem4pool,  mem5pool},
 
-    mem1table,
-    mem2table,
-    mem3table,
-    mem4table,
-    mem5table,
+    {mem1table, mem2table, mem3table, mem4table, mem5table},
 
-    MEMPOOL_INIT_READY,
-    MEMPOOL_INIT_READY,
-    MEMPOOL_INIT_READY,
-    MEMPOOL_INIT_READY,
-    MEMPOOL_INIT_READY
+    {MEMPOOL_INIT_READY, MEMPOOL_INIT_READY, MEMPOOL_INIT_READY,
+     MEMPOOL_INIT_READY, MEMPOOL_INIT_READY},
 };
 
 #if __linux__
@@ -105,6 +94,8 @@ static void mutex_creat(uint8_t memx)
 {
 #if __linux__
     pthread_mutex_init(&mutex[memx], NULL);
+#else
+    UNUSED(memx);
 #endif
 }
 
@@ -112,6 +103,8 @@ static void mutex_lock(uint8_t memx)
 {
 #if __linux__
     pthread_mutex_lock(&mutex[memx]);
+#else
+    UNUSED(memx);
 #endif
 }
 
@@ -119,6 +112,8 @@ static void mutex_unlock(uint8_t memx)
 {
 #if __linux__
     pthread_mutex_unlock(&mutex[memx]);
+#else
+    UNUSED(memx);
 #endif
 }
 
@@ -259,6 +254,9 @@ void myfree(void* ptr, char* file_name, uint32_t func_line)
         mymem_free(memx, offset);
 #if CONFIG_MEMORY_POOL_DEBUG
         memory_pool_debug_del(ptr, file_name, func_line);
+#else
+    UNUSED(file_name);
+    UNUSED(func_line);
 #endif
         mutex_unlock(memx);
     }
@@ -274,6 +272,9 @@ void* mymalloc(uint8_t memx, uint32_t size, char* file_name, uint32_t func_line)
         addr = (void*)((uintptr_t)malloc_dev.mempool[memx] + offset);
 #if CONFIG_MEMORY_POOL_DEBUG
         memory_pool_debug_add(memx, size, addr, file_name, func_line);
+#else
+    UNUSED(file_name);
+    UNUSED(func_line);
 #endif
     }
 

--- a/src/malloc.h
+++ b/src/malloc.h
@@ -21,6 +21,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifndef UNUSED
+#define UNUSED(x) ((void)(x))
+#endif /* UNUSED */
+
 #define SRAMIN   0x00
 #define SRAMEX   0x01
 #define SRAMCCM  0x02


### PR DESCRIPTION
fix build warnings
```
➜  /Users/junbozheng/project/cMemoryPool git:(master) ✗ cmake --build build -j16
[ 33%] Building C object CMakeFiles/mem_pool.dir/src/malloc.c.o
/Users/junbozheng/project/cMemoryPool/src/malloc.c:81:5: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
    mem1pool,
    ^~~~~~~~~
    {
/Users/junbozheng/project/cMemoryPool/src/malloc.c:87:5: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
    mem1table,
    ^~~~~~~~~~
    {
/Users/junbozheng/project/cMemoryPool/src/malloc.c:93:5: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
    MEMPOOL_INIT_READY,
    ^~~~~~~~~~~~~~~~~~~
    {
/Users/junbozheng/project/cMemoryPool/src/malloc.c:31:28: note: expanded from macro 'MEMPOOL_INIT_READY'
#define MEMPOOL_INIT_READY 0
                           ^
/Users/junbozheng/project/cMemoryPool/src/malloc.c:104:33: error: unused parameter 'memx' [-Werror,-Wunused-parameter]
static void mutex_creat(uint8_t memx)
                                ^
/Users/junbozheng/project/cMemoryPool/src/malloc.c:111:32: error: unused parameter 'memx' [-Werror,-Wunused-parameter]
static void mutex_lock(uint8_t memx)
                               ^
/Users/junbozheng/project/cMemoryPool/src/malloc.c:118:34: error: unused parameter 'memx' [-Werror,-Wunused-parameter]
static void mutex_unlock(uint8_t memx)
                                 ^
/Users/junbozheng/project/cMemoryPool/src/malloc.c:228:30: error: unused parameter 'file_name' [-Werror,-Wunused-parameter]
void myfree(void* ptr, char* file_name, uint32_t func_line)
                             ^
/Users/junbozheng/project/cMemoryPool/src/malloc.c:228:50: error: unused parameter 'func_line' [-Werror,-Wunused-parameter]
void myfree(void* ptr, char* file_name, uint32_t func_line)
                                                 ^
/Users/junbozheng/project/cMemoryPool/src/malloc.c:267:51: error: unused parameter 'file_name' [-Werror,-Wunused-parameter]
void* mymalloc(uint8_t memx, uint32_t size, char* file_name, uint32_t func_line)
                                                  ^
/Users/junbozheng/project/cMemoryPool/src/malloc.c:267:71: error: unused parameter 'func_line' [-Werror,-Wunused-parameter]
void* mymalloc(uint8_t memx, uint32_t size, char* file_name, uint32_t func_line)
                                                                      ^
10 errors generated.
make[2]: *** [CMakeFiles/mem_pool.dir/src/malloc.c.o] Error 1
make[1]: *** [CMakeFiles/mem_pool.dir/all] Error 2
make: *** [all] Error 2
```

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>