### PR TITLE
cmake: add always build source support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,3 +15,5 @@ add_executable(memorypool ${SRC})
 target_link_libraries(memorypool PRIVATE memory_pool)
 
 target_include_directories(memorypool PRIVATE src)
+
+add_dependencies(memorypool update_timestamp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,3 +23,6 @@ target_include_directories(memory_pool PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 
 # Add compile options for the memory pool target
 target_compile_options(memory_pool PRIVATE -Wall -Wextra -Werror -Wno-format -g)
+
+add_custom_target(update_timestamp COMMAND ${CMAKE_COMMAND} -E touch
+                                           ${CMAKE_CURRENT_LIST_DIR}/malloc.c)

--- a/src/malloc.c
+++ b/src/malloc.c
@@ -206,6 +206,8 @@ void mymem_init(uint8_t memx)
 #if CONFIG_MEMORY_POOL_DEBUG
     memory_pool_debug_init();
 #endif
+
+    printf("Memory pool %d init done %s\n", memx, __TIMESTAMP__);
 }
 
 uint8_t mem_perused(uint8_t memx)


### PR DESCRIPTION
```
➜  /Users/junbozheng/my/cMemoryPool git:(master) ✗
➜  /Users/junbozheng/my/cMemoryPool git:(master) ✗ cmake -S . -B build -GNinja
-- The C compiler identification is AppleClang 16.0.0.16000026
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Configuring done (1.0s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/junbozheng/my/cMemoryPool/build
➜  /Users/junbozheng/my/cMemoryPool git:(master) ✗ cmake --build build -j20
[5/5] Linking C executable memorypool
➜  /Users/junbozheng/my/cMemoryPool git:(master) ✗ ./build/memorypool
Memory pool 0 init done Tue Dec 31 23:22:07 2024
Memory pool 1 init done Tue Dec 31 23:22:07 2024
Memory pool 2 init done Tue Dec 31 23:22:07 2024
Memory pool 3 init done Tue Dec 31 23:22:07 2024
Memory pool 4 init done Tue Dec 31 23:22:07 2024
ptr malloc ok, addr: 0x1063a1070
ptr memory use info: 100%
ptr1 malloc fail, since memory usage: 100%
exit function run start
exit function run end
➜  /Users/junbozheng/my/cMemoryPool git:(master) ✗ cmake --build build -j20
[1/1] cd /Users/junbozheng/my/cMemoryPool/build/src && /usr/local/Cellar/cmake/3.27.2/bin/cmake -E touch /Users/junbozheng/my/cMemoryPool/src/malloc.c
➜  /Users/junbozheng/my/cMemoryPool git:(master) ✗ ./build/memorypool
Memory pool 0 init done Tue Dec 31 23:22:07 2024
Memory pool 1 init done Tue Dec 31 23:22:07 2024
Memory pool 2 init done Tue Dec 31 23:22:07 2024
Memory pool 3 init done Tue Dec 31 23:22:07 2024
Memory pool 4 init done Tue Dec 31 23:22:07 2024
ptr malloc ok, addr: 0x108bc4070
ptr memory use info: 100%
ptr1 malloc fail, since memory usage: 100%
exit function run start
exit function run end
➜  /Users/junbozheng/my/cMemoryPool git:(master) ✗ cmake --build build -j20
[4/4] Linking C executable memorypool
➜  /Users/junbozheng/my/cMemoryPool git:(master) ✗ ./build/memorypool
Memory pool 0 init done Tue Dec 31 23:22:19 2024
Memory pool 1 init done Tue Dec 31 23:22:19 2024
Memory pool 2 init done Tue Dec 31 23:22:19 2024
Memory pool 3 init done Tue Dec 31 23:22:19 2024
Memory pool 4 init done Tue Dec 31 23:22:19 2024
ptr malloc ok, addr: 0x10dd45070
ptr memory use info: 100%
ptr1 malloc fail, since memory usage: 100%
exit function run start
exit function run end
➜  /Users/junbozheng/my/cMemoryPool git:(master) ✗ cmake --build build -j20
[1/1] cd /Users/junbozheng/my/cMemoryPool/build/src && /usr/local/Cellar/cmake/3.27.2/bin/cmake -E touch /Users/junbozheng/my/cMemoryPool/src/malloc.c
➜  /Users/junbozheng/my/cMemoryPool git:(master) ✗ ./build/memorypool
Memory pool 0 init done Tue Dec 31 23:22:19 2024
Memory pool 1 init done Tue Dec 31 23:22:19 2024
Memory pool 2 init done Tue Dec 31 23:22:19 2024
Memory pool 3 init done Tue Dec 31 23:22:19 2024
Memory pool 4 init done Tue Dec 31 23:22:19 2024
ptr malloc ok, addr: 0x10822f070
ptr memory use info: 100%
ptr1 malloc fail, since memory usage: 100%
exit function run start
exit function run end
➜  /Users/junbozheng/my/cMemoryPool git:(master) ✗ cmake --build build -j20
[4/4] Linking C executable memorypool
➜  /Users/junbozheng/my/cMemoryPool git:(master) ✗ ./build/memorypool
Memory pool 0 init done Tue Dec 31 23:22:31 2024
Memory pool 1 init done Tue Dec 31 23:22:31 2024
Memory pool 2 init done Tue Dec 31 23:22:31 2024
Memory pool 3 init done Tue Dec 31 23:22:31 2024
Memory pool 4 init done Tue Dec 31 23:22:31 2024
ptr malloc ok, addr: 0x10aadc070
ptr memory use info: 100%
ptr1 malloc fail, since memory usage: 100%
exit function run start
exit function run end
```

 Signed-off-by: Junbo Zheng <3273070@qq.com>